### PR TITLE
Dev refactor command output

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -138,7 +138,6 @@ class TextCommand(Command):
         The InfoCommand causes the bot to send a message to the
         chat, as defined by its 'info' parameter.
         """
-        # self.bot.send_chat(self.text)
         return self.text
 
 
@@ -149,9 +148,6 @@ class FormatCommand(TextCommand):
         to the chat of the form str.format(**keys), where the keys
         correspond to state variables
         """
-        # self.bot.send_chat(
-        #     self.text.format(**self.bot.state)
-        # )
         return self.text.format(**self.bot.state)
 
 
@@ -182,27 +178,15 @@ class JsonCommand(TextCommand):
         return item
 
     def do(self, user, msg):
-        # self.bot.send_chat(
-        #     self.format_json()
-        # )
         return self.format_json()
 
 
 class ParseCommand(Command):
     def __init__(self, bot:Type[TwitchBot], name:str, restricted:bool):
         super(ParseCommand, self).__init__(bot, name, restricted)
-        # self.key = key
-        # self.sub_key = sub_key
     
     def do(self, user, msg):
         data = json.loads(msg)
-
-        # state = self.bot.state
-        # k, s = self.key, self.sub_key
-        # if self.sub_key:
-        #     state[k][s] = data
-        # else:
-        #     state[k] = data
 
         return data
 
@@ -219,9 +203,6 @@ class ChainCommand(Command):
 
         output = self.bot.get_output_buffer()
 
-        # output should be able to be either a str (chat message with interpolated arguments: "!cmd arg1 arg2")
-        #           OR an arbitrary object
-        #   need a way to keep straight various use cases when bot commands invoke other commands
         return self.do_other(self.in_command, user, output)
 
 
@@ -297,9 +278,6 @@ class OptionCommand(Command):
             return self.options[option](user, msg)
 
         else:
-            # self.bot.send_chat(
-            #     "Option '{}' not recognized".format(option)
-            # )
             return "Option '{}' not recognized".format(option)
 
 

--- a/commands.py
+++ b/commands.py
@@ -135,7 +135,8 @@ class TextCommand(Command):
         The InfoCommand causes the bot to send a message to the
         chat, as defined by its 'info' parameter.
         """
-        self.bot.send_chat(self.text)
+        # self.bot.send_chat(self.text)
+        return self.text
 
 
 class FormatCommand(TextCommand):
@@ -145,9 +146,10 @@ class FormatCommand(TextCommand):
         to the chat of the form str.format(**keys), where the keys
         correspond to state variables
         """
-        self.bot.send_chat(
-            self.text.format(**self.bot.state)
-        )
+        # self.bot.send_chat(
+        #     self.text.format(**self.bot.state)
+        # )
+        return self.text.format(**self.bot.state)
 
 
 class JsonCommand(TextCommand):
@@ -177,27 +179,29 @@ class JsonCommand(TextCommand):
         return item
 
     def do(self, *args):
-        self.bot.send_chat(
-            self.format_json()
-        )
+        # self.bot.send_chat(
+        #     self.format_json()
+        # )
+        return self.format_json()
 
 
 class ParseCommand(Command):
-    def __init__(self, bot: Type[TwitchBot], name: str, restricted: bool, key:str, sub_key:str=''):
+    def __init__(self, bot:Type[TwitchBot], name:str, restricted:bool, key:str, sub_key:str=''):
         super(ParseCommand, self).__init__(bot, name, restricted)
         self.key = key
         self.sub_key = sub_key
     
     def do(self, user, *args):
-        msg = args[1:].join(" ")
-        data = json.loads(msg)
+        data = json.loads(" ".join(args))
 
-        state = self.bot.state
-        k, s = self.key, self.sub_key
-        if self.sub_key:
-            state[k][s] = data
-        else:
-            state[k] = data
+        # state = self.bot.state
+        # k, s = self.key, self.sub_key
+        # if self.sub_key:
+        #     state[k][s] = data
+        # else:
+        #     state[k] = data
+
+        return data
 
 
 class ChainCommand(Command):
@@ -215,7 +219,7 @@ class ChainCommand(Command):
         # output should be able to be either a str (chat message with interpolated arguments: "!cmd arg1 arg2")
         #           OR an arbitrary object
         #   need a way to keep straight various use cases when bot commands invoke other commands
-        self.do_other(self.in_command, user, *output)
+        return self.do_other(self.in_command, user, *output)
 
 
 class AliasCommand(Command):
@@ -235,7 +239,7 @@ class AliasCommand(Command):
         specific set of arguments defined by the 'other' and 'msg'
         attributes.
         """
-        self.command_func(user, *self.args+args)
+        return self.command_func(user, *self.args+args)
 
 
 class SequenceCommand(Command):
@@ -288,12 +292,13 @@ class OptionCommand(Command):
         option = args.pop(0)
 
         if option in self.options:
-            self.options[option](user, *args)
+            return self.options[option](user, *args)
 
         else:
-            self.bot.send_chat(
-                "Option '{}' not recognized".format(option)
-            )
+            # self.bot.send_chat(
+            #     "Option '{}' not recognized".format(option)
+            # )
+            return "Option '{}' not recognized".format(option)
 
 
 class StateCommand(Command):
@@ -323,47 +328,28 @@ class StateCommand(Command):
         self.bot.set_state_variable(self.state_key, value)
 
 
-class SubStateCommand(Command):
-    def __init__(self, bot:Type[TwitchBot], name:str, restricted:bool, key:str, sub_key:str):
-        super(SubStateCommand, self).__init__(bot, name, restricted)
+# class PostCommand(Command):
+#     def __init__(self, bot:Type[TwitchBot], name:str, restricted:bool, url:str):
+#         super(PostCommand, self).__init__(bot, name, restricted)
+#         self.url = url.format(**bot.state)
 
-        self.state_key = key
-        self.sub_key = sub_key
-
-    def do(self, user, *args):
-        """
-        SubStateCommand modifies the value of a certain key within
-        a state variable that is a dict type object.
-        """
-        value = " ".join(args)
-
-        d = self.bot.state.get(self.state_key).copy()
-        d[self.sub_key] = value
-        self.bot.set_state_variable(self.state_key, d)
+#     def do(self, *args):
+#         """
+#         PostCommand sends a POST request to a URL defined by its 'url'
+#         parameter. The contents passed to this command represent the
+#         request body and typically should be properly formatted JSON.
+#         """
+#         user, *msg = args
+#         msg = " ".join(msg)
+#         self.bot.post_to_api(self.name, self.url, msg)
 
 
-class PostCommand(Command):
-    def __init__(self, bot:Type[TwitchBot], name:str, restricted:bool, url:str):
-        super(PostCommand, self).__init__(bot, name, restricted)
-        self.url = url.format(**bot.state)
-
-    def do(self, *args):
-        """
-        PostCommand sends a POST request to a URL defined by its 'url'
-        parameter. The contents passed to this command represent the
-        request body and typically should be properly formatted JSON.
-        """
-        user, *msg = args
-        msg = " ".join(msg)
-        self.bot.post_to_api(self.name, self.url, msg)
-
-
-class GetCommand(Command):
-    def __init__(self, bot: Type[TwitchBot], name: str, restricted: bool, url:str):
-        super(GetCommand, self).__init__(bot, name, restricted)
-        self.url = url.format(**bot.state)
+# class GetCommand(Command):
+#     def __init__(self, bot: Type[TwitchBot], name: str, restricted: bool, url:str):
+#         super(GetCommand, self).__init__(bot, name, restricted)
+#         self.url = url.format(**bot.state)
     
-    def do(self, *args):
-        data = self.bot.get_from_api(self.url)
+#     def do(self, *args):
+#         data = self.bot.get_from_api(self.url)
 
-        self.bot.send_chat(data)
+#         self.bot.send_chat(data)

--- a/commands.py
+++ b/commands.py
@@ -47,7 +47,7 @@ class Command:
         """
         pass
 
-    def do_other(self, name, user, msg):
+    def do_other(self, command, user, msg):
         """
         This method allows one command to invoke another
 
@@ -55,9 +55,9 @@ class Command:
         :param args:(str, str...), arbitrary arguments to be
             passed to other commmand
         """
-        self.bot.do_command(name, user, msg)
+        self.bot.do_command(command, user, msg)
 
-    def get_other(self, name, msg=''):
+    def get_other(self, command, msg=''):
         """
         This method returns an anonymous function that invokes a separate
         command with certain specified arguments passed to it, before
@@ -69,10 +69,10 @@ class Command:
             specified args passed to it
         """
         if not msg:
-            return lambda user, msg: self.do_other(name, user, msg)
+            return lambda user, new_msg: self.do_other(command, user, new_msg)
 
         else:
-            return lambda user, fake: self.do_other(name, user, msg)    # smells like code spirit
+            return lambda user, new_msg: self.do_other(command, user, msg)    # smells like code spirit
 
     def get_step_function(self, entry):
         """
@@ -113,7 +113,7 @@ class Command:
                 cls, *params = entry
                 command = cls(self.bot, "", self.restricted, *params)
 
-                return command.do
+                return self.get_other(command)
 
             else:
                 name, msg = entry
@@ -311,7 +311,7 @@ class StateCommand(Command):
 
 ##
 ## requests / API calls
-def make_request(method:str) -> Type(requests.post):
+def make_request(method:str) -> Type[requests.post]:
     return {
         "POST": requests.post,
         "GET": requests.get,

--- a/commands.py
+++ b/commands.py
@@ -309,6 +309,7 @@ class StateCommand(Command):
         self.bot.set_state_variable(self.state_key, msg)
 
 
+##
 ## requests / API calls
 def make_request(method:str) -> Type(requests.post):
     return {
@@ -340,11 +341,13 @@ def api_request(url:str, data:dict, method:str='GET', headers:None|dict=None) ->
 class RequestCommand(Command):
     def __init__(self, bot: Type[TwitchBot], name: str, restricted: bool, url:str, method:str):
         super(RequestCommand, self).__init__(bot, name, restricted)
-        self.url = url.format(**bot.state)
+        self.url = url
         self.method = method
 
     def do(self, user, msg):
-        return api_request(self.url, msg, self.method)
+        url = self.url.format(**self.bot.state)
+
+        return api_request(url, msg, self.method)
 
 
 class PostCommand(RequestCommand):

--- a/twitch_bot.py
+++ b/twitch_bot.py
@@ -1,6 +1,7 @@
 from twitch_chat import TwitchChat
 import json
 import requests
+import traceback
 
 """
     The twitch_bot.py module defines a TwitchBot class that manages a set of
@@ -83,8 +84,7 @@ class TwitchBot:
                 msg = "Runtime error occurred '{}: {}'".format(
                     e.__class__.__name__, e)
                 self.send_chat(msg)
-
-                raise e
+                print(traceback.format_exc())
 
     def set_output_buffer(self):
         self._buffer_flag = True
@@ -125,16 +125,16 @@ class TwitchBot:
         if msg[0] == "!":
             msg = msg.split(" ")
             command = msg[0][1:]
-            args = msg[1:]
+            msg = " ".join(msg[1:])
 
-            self.do_command(command, user, *args)
+            self.do_command(command, user, msg)
 
     def user_approved(self, command, user):
         authorized = user.upper() in [u.upper() for u in self.approved_users]
 
         return authorized if command.restricted else True
 
-    def do_command(self, command, user, *args):
+    def do_command(self, command, user, msg):
         """
         Checks for command name in commands dict and passes
         the user and args to the 'do' method of the associated
@@ -153,8 +153,8 @@ class TwitchBot:
         command = self.commands.get(command)
 
         if command and self.user_approved(command, user):
-            output = command.do(user, *args)
-            if output:
+            output = command.do(user, msg)
+            if output is not None:
               self.send_chat(output)
 
     def add_command(self, cls, *args):

--- a/twitch_bot.py
+++ b/twitch_bot.py
@@ -1,6 +1,5 @@
 from twitch_chat import TwitchChat
 import json
-import requests
 import traceback
 
 """
@@ -202,44 +201,3 @@ class TwitchBot:
         :return: value of the state variable, or None
         """
         return self.state.get(key)
-
-    @staticmethod
-    def post_to_api(command_name, url, msg):
-        try:
-            data = json.loads(msg)
-        except ValueError:
-            print("bad data passed to {}: \n{}".format(
-                command_name, msg
-            ))
-            return False
-
-        p = None
-        response = "\nRESPONSE FROM SERVER:\n {}"
-
-        try:
-            p = requests.post(
-                url, data=data, headers={'Content-type': 'application/json'}
-            )
-        except requests.ConnectionError:
-            error = "API POST request to {} failed to connect to server".format(url)
-            print(response.format(error))
-
-        if p:
-            print(response.format(p.text))
-    
-    @staticmethod
-    def get_from_api(url):
-        p = None
-        response = "\nRESPONSE FROM SERVER:\n {}"
-
-        try:
-            p = requests.get(
-                url, headers={'Content-type': 'application/json'}
-            )
-        except requests.ConnectionError:
-            error = "API POST request to {} failed to connect to server".format(url)
-            print(response.format(error))
-
-        if p:
-            print(response.format(p.text))
-            return p.json()

--- a/twitch_bot.py
+++ b/twitch_bot.py
@@ -100,10 +100,11 @@ class TwitchBot:
         """
         if not self._buffer_flag:
             # str conversion
-            if type(message) in (list, tuple):
-                message = " ".join([str(i) for i in message])
             if type(message) is not str:
                 message = str(message)
+            
+            if len(str) > 500:
+                message = message[:496] + "..."
 
             self.chat.send_chat(message)
 

--- a/twitch_bot.py
+++ b/twitch_bot.py
@@ -1,5 +1,4 @@
 from twitch_chat import TwitchChat
-import json
 import traceback
 
 """
@@ -93,24 +92,24 @@ class TwitchBot:
 
         return self._output_buffer
 
-    def send_chat(self, message:str|object):
+    def send_chat(self, msg:str|object):
         """
         Sends a message to the Twitch chat
         :param message: str, message for chat
         """
         if not self._buffer_flag:
             # str conversion
-            if type(message) is not str:
-                message = str(message)
+            if type(msg) is not str:
+                msg = str(msg)
             
-            if len(str) > 500:
-                message = message[:496] + "..."
+            if len(msg) > 500:
+                msg = msg[:496] + "..."
 
-            self.chat.send_chat(message)
+            self.chat.send_chat(msg)
 
         else:
             # if buffer flag set, store unconverted object
-            self._output_buffer = message
+            self._output_buffer = msg
 
     def handle_message(self, user, msg):
         """
@@ -150,7 +149,8 @@ class TwitchBot:
         if command == "bp" and user == "athenshorseparty_":
             breakpoint()
         
-        command = self.commands.get(command)
+        if type(command) is str:
+            command = self.commands.get(command)
 
         if command and self.user_approved(command, user):
             output = command.do(user, msg)

--- a/twitch_bot.py
+++ b/twitch_bot.py
@@ -100,10 +100,17 @@ class TwitchBot:
         :param message: str, message for chat
         """
         if not self._buffer_flag:
+            # str conversion
+            if type(message) in (list, tuple):
+                message = " ".join([str(i) for i in message])
+            if type(message) is not str:
+                message = str(message)
+
             self.chat.send_chat(message)
+
         else:
-            # self._output_buffer = message
-            self._output_buffer = message.split(" ")
+            # if buffer flag set, store unconverted object
+            self._output_buffer = message
 
     def handle_message(self, user, msg):
         """
@@ -146,11 +153,9 @@ class TwitchBot:
         command = self.commands.get(command)
 
         if command and self.user_approved(command, user):
-            # output = command.do(user, *args)
-            # if output:
-            #   self.send_chat
-
-            command.do(user, *args)
+            output = command.do(user, *args)
+            if output:
+              self.send_chat(output)
 
     def add_command(self, cls, *args):
         """

--- a/twitch_chat.py
+++ b/twitch_chat.py
@@ -1,5 +1,4 @@
 from socket import socket
-from typing import Type
 
 #   The twitch_chat.py module defines a class called TwitchChat that represents a
 # persistent connection to a Twitch chat room, using the IRC protocol with the

--- a/twitch_chat.py
+++ b/twitch_chat.py
@@ -1,5 +1,4 @@
 from socket import socket
-from twitch_bot import TwitchBot
 from typing import Type
 
 #   The twitch_chat.py module defines a class called TwitchChat that represents a
@@ -24,7 +23,7 @@ class TwitchChat:
     RECV_BUFFER_SIZE = 1024
     PRINT_FLAG = "print"
 
-    def __init__(self, user_name:str, token_file:str, channel:str, bot:Type[TwitchBot], output:None|str=None):
+    def __init__(self, user_name:str, token_file:str, channel:str, bot, output:None|str=None):
         """
         Returns a TwitchChat object and initializes a connection to the
         'irc.twitch.tv' server via a socket object imported from the


### PR DESCRIPTION
In addition to various QOL improvements like printing TB on errors, truncating chat messages from the bot, more type annotations etc., this branch:

* Establishes a new method signature convention for all command.do methods. 1 user and 1 "msg" is always passed, and it is up to the command subclass to decided what to do with that message.
* Also establishes new implementation where command.do returns its output, rather than calling TwitchBot.send_chat. This will help support future refactors for less dependency entanglement hopefully
* Refactors API requests such that other request types (PUT, PATCH) are easily extensible in the future, and TwitchBot.py no longer is concerned with requests
* RequestCommands now interpolate the URL string at invocation, not when initialized, so state var changes are still reflected in the request URL
* All inner commands now generate an anonymous wrapper of Command.do_other so that TwitchBot class is always able to monitor their output and decide whether to send it to chat or to the output buffer