### PR TITLE
Modular json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ oauth.token
 .vscode
 .TODO
 *.json
+modules/*

--- a/bot_loader.py
+++ b/bot_loader.py
@@ -58,7 +58,7 @@ class BotLoader:
         if modules:
             for path in modules:
                 if os.path.isdir(path):
-                    paths += os.listdir(path)
+                    paths += [os.path.join(path, f) for f in os.listdir(path) if '.json' in f]
                 else:
                     paths.append(path)
         
@@ -91,7 +91,7 @@ class BotLoader:
         :return: bot object with attributes, commands, listeners set
             according to JSON data
         """
-        data = cls.load_modules(cls, json_file)
+        data = cls.load_modules(json_file)
         
         loader = cls(
             data, classes=classes


### PR DESCRIPTION
This update includes support for the inclusion of modular json files to supplement the main `bot_settings.json` config file.

```json
{
  ...,
  "modules": []
}
```

The `"modules"` key defines a list that can contain **either** individual json files or directories that contain multiple json files.

If a directory is given it can be empty without raising an error, but individual files must actually exist.

Additional JSON modules can add commands to the `restricted` and `public` commands list and update initial `state` values as well.

**Note:** While the ordering of the list helps provide some direction for the ordering of value updates, `os.listdir` is called for directories that are provided and thus the ordering of the files within may be subject to the system environment and cannot be relied upon.