### PR TITLE
Extend HTTP verbs, extend JsonCommand to better support requests

### DIFF
--- a/bot_settings.json.EXAMPLE
+++ b/bot_settings.json.EXAMPLE
@@ -1,6 +1,6 @@
 {
   "restricted": [],
   "approved_users": [],
-  "classes": {},
+  "state": {},
   "public": []
 }

--- a/commands.py
+++ b/commands.py
@@ -3,7 +3,6 @@ from typing import Type
 import json
 import requests
 
-
 """  
     The commands.py module defines a Command class and collection of
 subclasses that provide various functions for the TwitchBot class
@@ -184,6 +183,8 @@ class JsonCommand(TextCommand):
 
     def do(self, user, msg):
         state = self.bot.state
+        state['user'] = user
+        state['msg'] = msg
         return self.format_json(self.text, state)
 
 
@@ -337,11 +338,13 @@ def api_request(url:str, data:dict, method:str='GET', headers:None|dict=None) ->
         )
     except requests.ConnectionError as e:
         error = "API request to {} failed:\n".format(url)
-        # error += e.response.text
         return error
     
     if p:
-        return p.json()
+        try:
+            return p.json()
+        except json.JSONDecodeError:
+            return p.text
 
 
 class RequestCommand(Command):

--- a/commands.py
+++ b/commands.py
@@ -318,7 +318,8 @@ def make_request(method:str) -> Type[requests.post]:
         "POST": requests.post,
         "GET": requests.get,
         "PUT": requests.put,
-        "PATCH": requests.patch
+        "PATCH": requests.patch,
+        "DELETE": requests.delete
     }[method]
 
 
@@ -341,20 +342,31 @@ def api_request(url:str, data:dict, method:str='GET', headers:None|dict=None) ->
 
 
 class RequestCommand(Command):
-    def __init__(self, bot: Type[TwitchBot], name: str, restricted: bool, url:str, method:str):
+    def __init__(self, bot: Type[TwitchBot], name: str, restricted: bool, url:str, method:str, headers:None|dict=None):
         super(RequestCommand, self).__init__(bot, name, restricted)
         self.url = url
         self.method = method
+        self.headers = headers
 
     def do(self, user, msg):
         url = self.url.format(**self.bot.state)
 
-        return api_request(url, msg, self.method)
+        return api_request(url, msg, self.method, self.headers)
 
 
 class PostCommand(RequestCommand):
-    def __init__(self, bot:Type[TwitchBot], name:str, restricted:bool, url:str):
+    def __init__(self, bot:Type[TwitchBot], name:str, restricted:bool, url:str, headers:None|dict=None):
         super(PostCommand, self).__init__(bot, name, restricted, url, 'POST')
+
+
+class PatchCommand(RequestCommand):
+    def __init__(self, bot:Type[TwitchBot], name:str, restricted:bool, url:str, headers:None|dict=None):
+        super(PatchCommand, self).__init__(bot, name, restricted, url, 'PATCH')
+
+
+class DeleteCommand(RequestCommand):
+    def __init__(self, bot:Type[TwitchBot], name:str, restricted:bool, url:str, headers:None|dict=None):
+        super(DeleteCommand, self).__init__(bot, name, restricted, url, 'DELETE')
 
 
 class GetCommand(RequestCommand):


### PR DESCRIPTION
This change introduces:

* A new set of classes for each of the HTTP verbs
* All of which now take a headers parameter which is now
* State interpolated using the same method as the JsonCommand class, which also now
* Can interpolate the special keys "{user}" and "{msg}" that correspond to the user name and the message used to invoke the command